### PR TITLE
[9.16.r1] Mark qti_kernel_headers as recovery_available

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,5 +1,6 @@
 cc_library_headers {
     name: "qti_kernel_headers_5.4",
     vendor_available: true,
+    recovery_available: true,
     export_include_dirs: ["kernel-headers"],
 }


### PR DESCRIPTION
Some future components require the kernel headers to be recovery_available.
```
error: vendor/qcom/opensource/recovery-ext/oem-recovery/Android.bp:25:1:
dependency "qti_kernel_headers" of "librecovery_updater" missing variant:
  os:android,image:recovery,arch:arm64_armv8-2a,sdk
```